### PR TITLE
fix: missing default exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './Tree';
+export * from './types';


### PR DESCRIPTION
The `package.json` contains the followiing references to the entry points:

```
  "main": "lib/index.js",
  "types": "lib/index.d.ts",
  "typings": "lib/index.d.ts",
```

However, these are not created during the build. These could be pointed to the correct files, or exported via an `index.ts`. Either way, this allows `import {Tree} from 'sonic-forest` rather than having to specify `import {Tree} from 'sonic-forest/lib/Tree`

There might be further files that require exporting. I just started to evaluate this lib, and immediately stumbled on this issue.